### PR TITLE
With the release of puppet-lint 2.0.0, support ~>2.0 versions.

### DIFF
--- a/puppet-lint-reference_on_declaration_outside_of_class-check.gemspec
+++ b/puppet-lint-reference_on_declaration_outside_of_class-check.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name        = 'puppet-lint-reference_on_declaration_outside_of_class-check'
-  spec.version     = '1.0.8'
+  spec.version     = '1.1.0'
   spec.homepage    = 'https://github.com/voxpupuli/puppet-lint-reference_on_declaration_outside_of_class-check'
   spec.license     = 'APL2'
   spec.author      = 'Martin Alfke'
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
     Extends puppet-lint to ensure that a reference is made only on a declaration within the same class
   EOF
 
-  spec.add_dependency             'puppet-lint', '~> 1.0'
+  spec.add_dependency             'puppet-lint', '~> 2.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its', '~> 1.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'


### PR DESCRIPTION
Many people are using puppet-lint from git head, and have been for a while. puppet-lint 2.0.0 was published today, with no actual changes other than the version number, but it breaks checks that specified `~>1.0`.
