### PR TITLE
fix spec tests

### DIFF
--- a/lib/puppet-lint/plugins/reference_on_foreign_class.rb
+++ b/lib/puppet-lint/plugins/reference_on_foreign_class.rb
@@ -2,7 +2,7 @@ PuppetLint.new_check(:reference_on_foreign_class) do
   def check
     has_declaration = 0
     tokens.select { |check_token|
-      [:CLASSREF].include? check_token.type
+      [:CLASSREF, :TYPE].include? check_token.type
     }.each do |check_token|
       check_classref = check_token.value.to_s.downcase
       check_title = check_token.next_token.next_token.value.to_s

--- a/puppet-lint-reference_on_declaration_outside_of_class-check.gemspec
+++ b/puppet-lint-reference_on_declaration_outside_of_class-check.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency             'puppet-lint', '>= 1.0', '< 3.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rspec-json_expectations', '~> 1.4'
   spec.add_development_dependency 'rspec-its', '~> 1.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'
   spec.add_development_dependency 'rake', '~> 0'


### PR DESCRIPTION
- add missing rspec-json-expectation gem
- a class declaration can be a CLASSREF or TYPE

Fixes build issues in #6 
@rnelson0 @juniorsysadmin please check for this build and rebase in case of no errors.